### PR TITLE
fix: fix flaky test assertions in org.apache.helix.rest.server.TestResourceAssignmentOptimizerAccessor#testComputePartitionAssignment

### DIFF
--- a/helix-rest/pom.xml
+++ b/helix-rest/pom.xml
@@ -184,6 +184,12 @@
       <artifactId>swagger-models</artifactId>
       <version>1.6.4</version>
     </dependency>
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <version>1.5.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAssignmentOptimizerAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAssignmentOptimizerAccessor.java
@@ -38,6 +38,8 @@ import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.rest.server.resources.helix.ResourceAssignmentOptimizerAccessor;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -99,7 +101,7 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
   }
 
   @Test
-  public void testComputePartitionAssignment() throws IOException {
+  public void testComputePartitionAssignment() throws IOException, JSONException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
 
     // Test AddInstances, RemoveInstances and SwapInstances
@@ -121,8 +123,7 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
     Assert.assertTrue(headers.containsKey(ResourceAssignmentOptimizerAccessor.RESPONSE_HEADER_KEY));
     Assert.assertFalse(
         headers.get(ResourceAssignmentOptimizerAccessor.RESPONSE_HEADER_KEY).isEmpty());
-    Assert.assertEquals(headers.get(ResourceAssignmentOptimizerAccessor.RESPONSE_HEADER_KEY).get(0),
-        "{instanceFilter=[], resourceFilter=[], returnFormat=IdealStateFormat}");
+    JSONAssert.assertEquals((String) headers.get(ResourceAssignmentOptimizerAccessor.RESPONSE_HEADER_KEY).get(0), "{instanceFilter=[], resourceFilter=[], returnFormat=IdealStateFormat}", false);
 
     // Test partitionAssignment InstanceFilter
     String payload2 = "{\"Options\" : { \"InstanceFilter\" : [\"" + liveInstances.get(0) + "\" , \""
@@ -146,14 +147,10 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
         headers2.get(ResourceAssignmentOptimizerAccessor.RESPONSE_HEADER_KEY);
     Assert.assertFalse(
         headers2.get(ResourceAssignmentOptimizerAccessor.RESPONSE_HEADER_KEY).isEmpty());
-    Assert.assertTrue(
-        partitionAssignmentMetadata2.get(0).equals(
-            "{instanceFilter=[" + liveInstances.get(0) + ", " + liveInstances.get(1)
-            + "], resourceFilter=[], returnFormat=IdealStateFormat}") ||
-        partitionAssignmentMetadata2.get(0).equals(
-            "{instanceFilter=[" + liveInstances.get(1) + ", " + liveInstances.get(0)
-                + "], resourceFilter=[], returnFormat=IdealStateFormat}"),
-        partitionAssignmentMetadata2.get(0).toString());
+    JSONAssert.assertEquals("{instanceFilter=[" + liveInstances.get(0) + ", " + liveInstances.get(1) + "], "
+    + "resourceFilter=[], " + "returnFormat=IdealStateFormat}", partitionAssignmentMetadata2.get(0).toString(), false);
+    JSONAssert.assertEquals("{instanceFilter=[" + liveInstances.get(0) + ", " + liveInstances.get(1) + "], "
+        + "resourceFilter=[], " + "returnFormat=IdealStateFormat}", ((String) partitionAssignmentMetadata2.get(0)), false);
 
     // Test partitionAssignment ResourceFilter
     String payload3 =
@@ -177,14 +174,8 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
         headers3.get(ResourceAssignmentOptimizerAccessor.RESPONSE_HEADER_KEY);
     Assert.assertFalse(
         headers3.get(ResourceAssignmentOptimizerAccessor.RESPONSE_HEADER_KEY).isEmpty());
-    Assert.assertTrue(
-        partitionAssignmentMetadata3.get(0).equals(
-            "{instanceFilter=[], resourceFilter=[" + resources.get(0) + ", " + resources.get(1)
-                + "], returnFormat=IdealStateFormat}") ||
-        partitionAssignmentMetadata3.get(0).equals(
-                "{instanceFilter=[], resourceFilter=[" + resources.get(1) + ", " + resources.get(0)
-                    + "], returnFormat=IdealStateFormat}"),
-        partitionAssignmentMetadata3.get(0).toString());
+    JSONAssert.assertEquals("{instanceFilter=[], resourceFilter=[" + resources.get(0) + ", " + resources.get(1)
+        + "], returnFormat=IdealStateFormat}", partitionAssignmentMetadata3.get(0).toString(), false);
 
     // Test Option CurrentState format with AddInstances, RemoveInstances and SwapInstances
     String payload4 = "{\"InstanceChange\" : { \"ActivateInstances\" : [\"" + toEnabledInstance
@@ -211,14 +202,9 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
         headers4.get(ResourceAssignmentOptimizerAccessor.RESPONSE_HEADER_KEY);
     Assert.assertFalse(
         headers4.get(ResourceAssignmentOptimizerAccessor.RESPONSE_HEADER_KEY).isEmpty());
-    Assert.assertTrue(
-        partitionAssignmentMetadata4.get(0).equals(
-            "{instanceFilter=[], resourceFilter=[" + resources.get(0) + ", " + resources.get(1)
-                + "], returnFormat=CurrentStateFormat}") ||
-        partitionAssignmentMetadata4.get(0).equals(
-                "{instanceFilter=[], resourceFilter=[" + resources.get(1) + ", " + resources.get(0)
-                    + "], returnFormat=CurrentStateFormat}"),
-        partitionAssignmentMetadata4.get(0).toString());
+    JSONAssert.assertEquals(partitionAssignmentMetadata4.get(0).toString(),
+      "{instanceFilter=[], resourceFilter=[" + resources.get(0) + ", " + resources.get(1)+ "], returnFormat" +
+      "=CurrentStateFormat}",false);
 
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #2640
<!-- (#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved) -->

### Description

The problem in this test is, that a json string gets directly asserted. JSON strings are equal, if it has the same content and structure. Not only the elements in the arrays can change, but also the elements in the same object can change place. This is not considered in the assertion and leads to a flaky test.

This problem was found by the NonDex Engine – to reproduce run
```shell
mvn -pl helix-rest edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.helix.rest.server.TestResourceAssignmentOptimizerAccessor#testComputePartitionAssignment
``` 

### Tests

No test have been written – one existing test has been updated.

- The following is the result of the "mvn test" command on the appropriate module:
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:53 min
[INFO] Finished at: 2023-10-04T18:42:54-05:00

